### PR TITLE
Abandon requester task

### DIFF
--- a/cloud/cloud.js
+++ b/cloud/cloud.js
@@ -34,42 +34,197 @@ async function checkTaskerClaimedTask(ethAddress, taskId) {
 
 /* ------------------------------------------------------------------- */
 
-Moralis.Cloud.define("checkTaskerClaimedTask", async (request) => {
-  const ethAddress = request.user.get("ethAddress");
-  const taskId = request.params.taskId;
-  return await checkTaskerClaimedTask(ethAddress, taskId);
-});
+Moralis.Cloud.define(
+  "checkTaskerClaimedTask",
+  async (request) => {
+    const ethAddress = request.user.get("ethAddress");
+    const taskId = request.params.taskId;
+    return await checkTaskerClaimedTask(ethAddress, taskId);
+  },
+  {
+    fields: ["taskId"],
+    requireUser: true,
+  }
+);
 
 /* ------------------------------------------------------------------- */
 
-Moralis.Cloud.define("makeOrGetNewUser", async (request) => {
-  const ethAddress = request.user.get("ethAddress");
-  const tableName = "Users";
-  const defaultDisplayName = "GIG User";
+Moralis.Cloud.define(
+  "makeOrGetNewUser",
+  async (request) => {
+    const ethAddress = request.user.get("ethAddress");
+    const tableName = "Users";
+    const defaultDisplayName = "GIG User";
 
-  const Users = Moralis.Object.extend(tableName);
-  const query = new Moralis.Query(Users);
-  const res = await query.equalTo("ethAddress", ethAddress).find();
+    const Users = Moralis.Object.extend(tableName);
+    const query = new Moralis.Query(Users);
+    const res = await query.equalTo("ethAddress", ethAddress).find();
 
-  if (res.length > 0) return res[0];
+    if (res.length > 0) return res[0];
 
-  const user = new Users();
-  user.set("ethAddress", ethAddress);
-  user.set("displayName", defaultDisplayName);
-  user.set("email", null);
-  user.set("requesterRating", null);
-  await user.save();
+    const user = new Users();
+    user.set("ethAddress", ethAddress);
+    user.set("displayName", defaultDisplayName);
+    user.set("email", null);
+    user.set("requesterRating", null);
+    await user.save();
 
-  return user;
-});
+    return user;
+  },
+  {
+    requireUser: true,
+  }
+);
 
 /* ------------------------------------------------------------------- */
 
-Moralis.Cloud.define("getBrowseTasksTableData", async (request) => {
-  /*
+Moralis.Cloud.define(
+  "getBrowseTasksTableData",
+  async (request) => {
+    /*
     Retreives the task IDs for the tasks a user has claimed.
   */
-  async function getTaskerClaimedTaskIds(ethAddress) {
+    async function getTaskerClaimedTaskIds(ethAddress) {
+      const tableName = "TaskUsers";
+
+      const TaskUsers = Moralis.Object.extend(tableName);
+      const query = new Moralis.Query(TaskUsers);
+      const res = query.aggregate([
+        { match: { taskerId: ethAddress } },
+        { project: { objectId: 0, taskId: 1 } },
+      ]);
+
+      return res;
+    }
+
+    const ethAddress = request.user.get("ethAddress");
+    const tableName = "Tasks";
+
+    const Tasks = Moralis.Object.extend(tableName);
+    const query = new Moralis.Query(Tasks);
+    const res = await query.aggregate([
+      { sort: { unitRewardWei: -1 } },
+      {
+        project: {
+          objectId: 1, // taskId
+          title: 1,
+          avgRating: 1,
+          unitRewardWei: 1,
+          maxRewardWei: 1,
+          requesterId: 1,
+          numResponses: 1,
+          maxResponses: 1,
+          status: 1,
+        },
+      },
+    ]);
+
+    const claimedTaskIds = {};
+    (await getTaskerClaimedTaskIds(ethAddress)).forEach((task) => {
+      claimedTaskIds[task["taskId"]] = 1;
+    });
+
+    /*
+    Filters:
+      1. Remove tasks already claimed by the user
+      2. Remove tasks that have reached the claim limit
+      3. Remove tasks that, upon claiming, would go over the ETH allocation
+      4. Remove tasks that are not in progress
+  */
+    return res.filter((task) => {
+      return (
+        !(task["objectId"] in claimedTaskIds) &&
+        task["numResponses"] < task["maxResponses"] &&
+        task["maxRewardWei"] -
+          (task["numResponses"] + 1) * task["unitRewardWei"] >=
+          0 &&
+        task["status"] === 0
+      );
+    });
+  },
+  {
+    requireUser: true,
+  }
+);
+
+/* ------------------------------------------------------------------- */
+
+Moralis.Cloud.define(
+  "getTaskerMyTasksTableData",
+  async (request) => {
+    const ethAddress = request.user.get("ethAddress");
+    const tableName = "TaskUsers";
+
+    const TaskUsers = Moralis.Object.extend(tableName);
+    const query = new Moralis.Query(TaskUsers);
+    const res = await query.aggregate([
+      { match: { taskerId: ethAddress } },
+      { project: { objectId: 0, taskId: 1, status: 1 } },
+      {
+        lookup: {
+          from: "Tasks",
+          localField: "taskId",
+          foreignField: "_id", // taskId
+          as: "tasks",
+        },
+      },
+    ]);
+
+    /*
+    Filters:
+      1. Remove tasks claims that are in progress, but the task is not in progress
+  */
+    return res.filter((task) => {
+      if (task["tasks"].length !== 1) return false;
+      if (task["status"] === 0 && task["tasks"][0]["status"] !== 0)
+        return false;
+      return true;
+    });
+  },
+  {
+    requireUser: true,
+  }
+);
+
+/* ------------------------------------------------------------------- */
+
+Moralis.Cloud.define(
+  "getRequesterCreatedTasksTableData",
+  async (request) => {
+    const ethAddress = request.user.get("ethAddress");
+    const tableName = "Tasks";
+
+    const Tasks = Moralis.Object.extend(tableName);
+    const query = new Moralis.Query(Tasks);
+    const res = query.aggregate([
+      { match: { requesterId: ethAddress } },
+      { sort: { status: 1 } },
+      {
+        project: {
+          objectId: 1, // taskId
+          title: 1,
+          unitRewardWei: 1,
+          maxRewardWei: 1,
+          status: 1,
+          numResponses: 1,
+          maxResponses: 1,
+        },
+      },
+    ]);
+
+    return res;
+  },
+  {
+    requireUser: true,
+  }
+);
+
+/* ------------------------------------------------------------------- */
+
+Moralis.Cloud.define(
+  "getTaskerClaimedTaskIds",
+  async (request) => {
+    const ethAddress = request.user.get("ethAddress");
     const tableName = "TaskUsers";
 
     const TaskUsers = Moralis.Object.extend(tableName);
@@ -80,438 +235,353 @@ Moralis.Cloud.define("getBrowseTasksTableData", async (request) => {
     ]);
 
     return res;
+  },
+  {
+    requireUser: true,
   }
-
-  const ethAddress = request.user.get("ethAddress");
-  const tableName = "Tasks";
-
-  const Tasks = Moralis.Object.extend(tableName);
-  const query = new Moralis.Query(Tasks);
-  const res = await query.aggregate([
-    { sort: { unitRewardWei: -1 } },
-    {
-      project: {
-        objectId: 1, // taskId
-        title: 1,
-        avgRating: 1,
-        unitRewardWei: 1,
-        maxRewardWei: 1,
-        requesterId: 1,
-        numResponses: 1,
-        maxResponses: 1,
-        status: 1,
-      },
-    },
-  ]);
-
-  const claimedTaskIds = {};
-  (await getTaskerClaimedTaskIds(ethAddress)).forEach((task) => {
-    claimedTaskIds[task["taskId"]] = 1;
-  });
-
-  /*
-    Filters:
-      1. Remove tasks already claimed by the user
-      2. Remove tasks that have reached the claim limit
-      3. Remove tasks that, upon claiming, would go over the ETH allocation
-      4. Remove tasks that are not in progress
-  */
-  return res.filter((task) => {
-    return (
-      !(task["objectId"] in claimedTaskIds) &&
-      task["numResponses"] < task["maxResponses"] &&
-      task["maxRewardWei"] -
-        (task["numResponses"] + 1) * task["unitRewardWei"] >=
-        0 &&
-      task["status"] === 0
-    );
-  });
-});
+);
 
 /* ------------------------------------------------------------------- */
 
-Moralis.Cloud.define("getTaskerMyTasksTableData", async (request) => {
-  const ethAddress = request.user.get("ethAddress");
-  const tableName = "TaskUsers";
-
-  const TaskUsers = Moralis.Object.extend(tableName);
-  const query = new Moralis.Query(TaskUsers);
-  const res = await query.aggregate([
-    { match: { taskerId: ethAddress } },
-    { project: { objectId: 0, taskId: 1, status: 1 } },
-    {
-      lookup: {
-        from: "Tasks",
-        localField: "taskId",
-        foreignField: "_id", // taskId
-        as: "tasks",
-      },
-    },
-  ]);
-
-  /*
-    Filters:
-      1. Remove tasks claims that are in progress, but the task is not in progress
-  */
-  return res.filter((task) => {
-    if (task["tasks"].length !== 1) return false;
-    if (task["status"] === 0 && task["tasks"][0]["status"] !== 0) return false;
-    return true;
-  });
-});
-
-/* ------------------------------------------------------------------- */
-
-Moralis.Cloud.define("getRequesterCreatedTasksTableData", async (request) => {
-  const ethAddress = request.user.get("ethAddress");
-  const tableName = "Tasks";
-
-  const Tasks = Moralis.Object.extend(tableName);
-  const query = new Moralis.Query(Tasks);
-  const res = query.aggregate([
-    { match: { requesterId: ethAddress } },
-    { sort: { status: 1 } },
-    {
-      project: {
-        objectId: 1, // taskId
-        title: 1,
-        unitRewardWei: 1,
-        maxRewardWei: 1,
-        status: 1,
-        numResponses: 1,
-        maxResponses: 1,
-      },
-    },
-  ]);
-
-  return res;
-});
-
-/* ------------------------------------------------------------------- */
-
-Moralis.Cloud.define("getTaskerClaimedTaskIds", async (request) => {
-  const ethAddress = request.user.get("ethAddress");
-  const tableName = "TaskUsers";
-
-  const TaskUsers = Moralis.Object.extend(tableName);
-  const query = new Moralis.Query(TaskUsers);
-  const res = query.aggregate([
-    { match: { taskerId: ethAddress } },
-    { project: { objectId: 0, taskId: 1 } },
-  ]);
-
-  return res;
-});
-
-/* ------------------------------------------------------------------- */
-
-Moralis.Cloud.define("getTaskOverviewData", async (request) => {
-  const taskId = request.params.taskId;
-  const tableName = "Tasks";
-
-  const Tasks = Moralis.Object.extend(tableName);
-  const query = new Moralis.Query(Tasks);
-  const res = query.aggregate([
-    { match: { _id: taskId } },
-    {
-      project: {
-        objectId: 0,
-        title: 1,
-        description: 1,
-        startDate: 1,
-        unitRewardWei: 1,
-        estCompletionTime: 1,
-        avgRating: 1,
-        requesterId: 1,
-      },
-    },
-  ]);
-
-  return res;
-});
-
-/* ------------------------------------------------------------------- */
-
-Moralis.Cloud.define("taskerClaimTask", async (request) => {
-  const ClaimCheckOutcome = {
-    GOOD: "GOOD",
-    OTHER: "OTHER",
-    BOTH: "BOTH",
-    RESPONSES: "RESPONSES",
-    ETH: "ETH",
-    BAD_STATUS: "BAD_STATUS",
-  };
-
-  async function incrementNumTaskers(taskId) {
+Moralis.Cloud.define(
+  "getTaskOverviewData",
+  async (request) => {
+    const taskId = request.params.taskId;
     const tableName = "Tasks";
 
     const Tasks = Moralis.Object.extend(tableName);
     const query = new Moralis.Query(Tasks);
-    const res = await query.equalTo("objectId", taskId).first();
+    const res = query.aggregate([
+      { match: { _id: taskId } },
+      {
+        project: {
+          objectId: 0,
+          title: 1,
+          description: 1,
+          startDate: 1,
+          unitRewardWei: 1,
+          estCompletionTime: 1,
+          avgRating: 1,
+          requesterId: 1,
+        },
+      },
+    ]);
 
-    res.set("numResponses", res.get("numResponses") + 1);
-    await res.save();
+    return res;
+  },
+  {
+    fields: ["taskId"],
+    requireUser: true,
   }
-
-  async function checkClaimAvailability(taskId) {
-    const tableName = "Tasks";
-
-    const Tasks = Moralis.Object.extend(tableName);
-    const query = new Moralis.Query(Tasks);
-    const res = await query.equalTo("objectId", taskId).find();
-
-    if (res.length !== 1) return ClaimCheckOutcome.OTHER;
-
-    const task = res[0];
-    const blameResponses = task.get("numResponses") >= task.get("maxResponses");
-    const blameETH =
-      task.get("maxRewardWei") -
-        (task.get("numResponses") + 1) * task.get("unitRewardWei") <
-      0;
-    const blameStatus = task.get("status") !== 0;
-
-    if (blameResponses && blameETH) return ClaimCheckOutcome.BOTH;
-    if (blameResponses) return ClaimCheckOutcome.RESPONSES;
-    if (blameETH) return ClaimCheckOutcome.ETH;
-    if (blameStatus) return ClaimCheckOutcome.BAD_STATUS;
-
-    return ClaimCheckOutcome.GOOD;
-  }
-
-  const ethAddress = request.user.get("ethAddress");
-  const taskId = request.params.taskId;
-
-  const check = await checkClaimAvailability(taskId);
-  if (check === ClaimCheckOutcome.OTHER)
-    return {
-      success: false,
-      message: `Address ${ethAddress} failed to claim task ${taskId}: reason unknown`,
-    };
-  if (check === ClaimCheckOutcome.BOTH)
-    return {
-      success: false,
-      message: `Address ${ethAddress} failed to claim task ${taskId}: Tasker limit and ETH allocation both exceeded`,
-    };
-  if (check === ClaimCheckOutcome.RESPONSES)
-    return {
-      success: false,
-      message: `Address ${ethAddress} failed to claim task ${taskId}: Tasker limit exceeded`,
-    };
-  if (check === ClaimCheckOutcome.ETH)
-    return {
-      success: false,
-      message: `Address ${ethAddress} failed to claim task ${taskId}: ETH allocation exceeded`,
-    };
-  if (check === ClaimCheckOutcome.BAD_STATUS)
-    return {
-      success: false,
-      message: `Address ${ethAddress} failed to claim task ${taskId}: task is no longer in progress`,
-    };
-
-  if (await checkTaskerClaimedTask(ethAddress, taskId))
-    return {
-      success: false,
-      message: `Address ${ethAddress} has already claimed task ${taskId}.`,
-    };
-
-  // At this point, it is safe to proceed with the task claim operation
-
-  await incrementNumTaskers(taskId);
-
-  const tableName = "TaskUsers";
-  const TaskUsers = Moralis.Object.extend(tableName);
-
-  const taskUser = new TaskUsers();
-  taskUser.set("taskerId", ethAddress);
-  taskUser.set("taskId", taskId);
-  taskUser.set("startDate", new Date());
-  taskUser.set("completedDate", null);
-  taskUser.set("taskerRating", null);
-  taskUser.set("status", 0);
-  taskUser.set("hasRated", false);
-  await taskUser.save();
-
-  return {
-    success: true,
-    message: `Address ${ethAddress} successfully claimed task ${taskId}!`,
-  };
-});
+);
 
 /* ------------------------------------------------------------------- */
 
-Moralis.Cloud.define("taskerAbandonTask", async (request) => {
-  async function decrementNumTaskers(taskId) {
-    const tableName = "Tasks";
-
-    const Tasks = Moralis.Object.extend(tableName);
-    const query = new Moralis.Query(Tasks);
-    const res = await query.equalTo("objectId", taskId).first();
-
-    // Handles case where Requester has abandoned task, so query result is null
-    if (!res) return;
-
-    // Do not affect numResponses count if task is no longer in progress
-    if (res.get("status") !== 0) return;
-
-    res.set("numResponses", res.get("numResponses") - 1);
-    await res.save();
-  }
-
-  const ethAddress = request.user.get("ethAddress");
-  const taskId = request.params.taskId;
-
-  if (!(await checkTaskerClaimedTask(ethAddress, taskId)))
-    return {
-      success: false,
-      message: `Address ${ethAddress} has not claimed task ${taskId}.`,
+Moralis.Cloud.define(
+  "taskerClaimTask",
+  async (request) => {
+    const ClaimCheckOutcome = {
+      GOOD: "GOOD",
+      OTHER: "OTHER",
+      BOTH: "BOTH",
+      RESPONSES: "RESPONSES",
+      ETH: "ETH",
+      BAD_STATUS: "BAD_STATUS",
     };
 
-  const tableName = "TaskUsers";
-  const TaskUsers = Moralis.Object.extend(tableName);
+    async function incrementNumTaskers(taskId) {
+      const tableName = "Tasks";
 
-  const query = new Moralis.Query(TaskUsers);
-  const res = await query
-    .equalTo("taskerId", ethAddress)
-    .equalTo("taskId", taskId)
-    .first();
+      const Tasks = Moralis.Object.extend(tableName);
+      const query = new Moralis.Query(Tasks);
+      const res = await query.equalTo("objectId", taskId).first();
 
-  if (!res)
-    return {
-      success: false,
-      message: `Address ${ethAddress} failed to abandon task ${taskId}: task is not claimed`,
-    };
+      res.set("numResponses", res.get("numResponses") + 1);
+      await res.save();
+    }
 
-  // Do not allow task abandonment if its status is not in progress
-  if (res.get("status") !== 0)
-    return {
-      success: false,
-      message: `Address ${ethAddress} failed to abandon task ${taskId}: task is not in progress`,
-    };
+    async function checkClaimAvailability(taskId) {
+      const tableName = "Tasks";
 
-  return res.destroy().then(
-    async () => {
-      await decrementNumTaskers(taskId);
-      return {
-        success: true,
-        message: `Address ${ethAddress} successfully abandoned task ${taskId}!`,
-      };
-    },
-    (error) => {
+      const Tasks = Moralis.Object.extend(tableName);
+      const query = new Moralis.Query(Tasks);
+      const res = await query.equalTo("objectId", taskId).find();
+
+      if (res.length !== 1) return ClaimCheckOutcome.OTHER;
+
+      const task = res[0];
+      const blameResponses =
+        task.get("numResponses") >= task.get("maxResponses");
+      const blameETH =
+        task.get("maxRewardWei") -
+          (task.get("numResponses") + 1) * task.get("unitRewardWei") <
+        0;
+      const blameStatus = task.get("status") !== 0;
+
+      if (blameResponses && blameETH) return ClaimCheckOutcome.BOTH;
+      if (blameResponses) return ClaimCheckOutcome.RESPONSES;
+      if (blameETH) return ClaimCheckOutcome.ETH;
+      if (blameStatus) return ClaimCheckOutcome.BAD_STATUS;
+
+      return ClaimCheckOutcome.GOOD;
+    }
+
+    const ethAddress = request.user.get("ethAddress");
+    const taskId = request.params.taskId;
+
+    const check = await checkClaimAvailability(taskId);
+    if (check === ClaimCheckOutcome.OTHER)
       return {
         success: false,
-        message: `Address ${ethAddress} failed to abandon task ${taskId}: ${error}`,
+        message: `Address ${ethAddress} failed to claim task ${taskId}: reason unknown`,
       };
-    }
-  );
-});
+    if (check === ClaimCheckOutcome.BOTH)
+      return {
+        success: false,
+        message: `Address ${ethAddress} failed to claim task ${taskId}: Tasker limit and ETH allocation both exceeded`,
+      };
+    if (check === ClaimCheckOutcome.RESPONSES)
+      return {
+        success: false,
+        message: `Address ${ethAddress} failed to claim task ${taskId}: Tasker limit exceeded`,
+      };
+    if (check === ClaimCheckOutcome.ETH)
+      return {
+        success: false,
+        message: `Address ${ethAddress} failed to claim task ${taskId}: ETH allocation exceeded`,
+      };
+    if (check === ClaimCheckOutcome.BAD_STATUS)
+      return {
+        success: false,
+        message: `Address ${ethAddress} failed to claim task ${taskId}: task is no longer in progress`,
+      };
+
+    if (await checkTaskerClaimedTask(ethAddress, taskId))
+      return {
+        success: false,
+        message: `Address ${ethAddress} has already claimed task ${taskId}.`,
+      };
+
+    // At this point, it is safe to proceed with the task claim operation
+
+    await incrementNumTaskers(taskId);
+
+    const tableName = "TaskUsers";
+    const TaskUsers = Moralis.Object.extend(tableName);
+
+    const taskUser = new TaskUsers();
+    taskUser.set("taskerId", ethAddress);
+    taskUser.set("taskId", taskId);
+    taskUser.set("startDate", new Date());
+    taskUser.set("completedDate", null);
+    taskUser.set("taskerRating", null);
+    taskUser.set("status", 0);
+    taskUser.set("hasRated", false);
+    await taskUser.save();
+
+    return {
+      success: true,
+      message: `Address ${ethAddress} successfully claimed task ${taskId}!`,
+    };
+  },
+  {
+    fields: ["taskId"],
+    requireUser: true,
+  }
+);
 
 /* ------------------------------------------------------------------- */
 
-Moralis.Cloud.define("createTask", async (request) => {
-  const QuestionType = {
-    SINGLE_CHOICE: 0,
-  };
+Moralis.Cloud.define(
+  "taskerAbandonTask",
+  async (request) => {
+    async function decrementNumTaskers(taskId) {
+      const tableName = "Tasks";
 
-  function validateNewTask(newTask, maxRewardETH, maxResponses, config) {
-    const MIN_TASKERS = Number(config.get("NEXT_PUBLIC_MIN_TASKERS"));
-    const MIN_TASK_DATA_CHARS = Number(
-      config.get("NEXT_PUBLIC_MIN_TASK_DATA_CHARS")
+      const Tasks = Moralis.Object.extend(tableName);
+      const query = new Moralis.Query(Tasks);
+      const res = await query.equalTo("objectId", taskId).first();
+
+      // Handles case where Requester has abandoned task, so query result is null
+      if (!res) return;
+
+      // Do not affect numResponses count if task is no longer in progress
+      if (res.get("status") !== 0) return;
+
+      res.set("numResponses", res.get("numResponses") - 1);
+      await res.save();
+    }
+
+    const ethAddress = request.user.get("ethAddress");
+    const taskId = request.params.taskId;
+
+    if (!(await checkTaskerClaimedTask(ethAddress, taskId)))
+      return {
+        success: false,
+        message: `Address ${ethAddress} has not claimed task ${taskId}.`,
+      };
+
+    const tableName = "TaskUsers";
+    const TaskUsers = Moralis.Object.extend(tableName);
+
+    const query = new Moralis.Query(TaskUsers);
+    const res = await query
+      .equalTo("taskerId", ethAddress)
+      .equalTo("taskId", taskId)
+      .first();
+
+    if (!res)
+      return {
+        success: false,
+        message: `Address ${ethAddress} failed to abandon task ${taskId}: task is not claimed`,
+      };
+
+    // Do not allow task abandonment if its status is not in progress
+    if (res.get("status") !== 0)
+      return {
+        success: false,
+        message: `Address ${ethAddress} failed to abandon task ${taskId}: task is not in progress`,
+      };
+
+    return res.destroy().then(
+      async () => {
+        await decrementNumTaskers(taskId);
+        return {
+          success: true,
+          message: `Address ${ethAddress} successfully abandoned task ${taskId}!`,
+        };
+      },
+      (error) => {
+        return {
+          success: false,
+          message: `Address ${ethAddress} failed to abandon task ${taskId}: ${error}`,
+        };
+      }
     );
-    const MIN_ETH = Number(config.get("NEXT_PUBLIC_MIN_ETH"));
-
-    if (maxRewardETH < MIN_ETH) return false;
-    if (maxResponses < MIN_TASKERS) return false;
-    if (!Number.isInteger(maxResponses)) return false;
-    if (newTask["title"].length < MIN_TASK_DATA_CHARS) return false;
-    if (newTask["description"].length < MIN_TASK_DATA_CHARS) return false;
-    if (
-      newTask["questions"].some(
-        (question) => question["question"].length < MIN_TASK_DATA_CHARS
-      )
-    )
-      return false;
-    if (
-      newTask["questions"].some((question) => {
-        // See enum QuestionType for type IDs
-
-        // Multiple choice
-        if (question["type"] === QuestionType.SINGLE_CHOICE) {
-          // Check that number of choices is in [1, 5]
-          if (question["options"].length < 1 || question["options"].length > 5)
-            return true;
-          return false;
-        }
-
-        // Invalid/unknown question type, so fail
-        return true;
-      })
-    )
-      return false;
-
-    // All checks passed at this point
-    return true;
+  },
+  {
+    fields: ["taskId"],
+    requireUser: true,
   }
+);
 
-  async function insertNewTask(newTask, maxRewardETH, maxResponses) {
-    const tableName = "Tasks";
+/* ------------------------------------------------------------------- */
 
-    const Tasks = Moralis.Object.extend(tableName);
-
-    const task = new Tasks();
-    task.set("requesterId", ethAddress);
-    task.set("title", newTask["title"]);
-    task.set("description", newTask["description"]);
-    task.set("startDate", new Date());
-    task.set("status", 0); // "in progress"
-    task.set(
-      "estCompletionTime",
-      Math.ceil((newTask["questions"].length * 30) / 60)
-    ); // approx 30 seconds per question @bzzbbz @christine-sun @jennsun @nicholaspad
-    task.set("avgRating", -1);
-    task.set("numResponses", 0);
-    task.set("maxResponses", maxResponses);
-    task.set(
-      "unitRewardWei",
-      await computeUnitRewardWei(maxRewardETH, maxResponses)
-    );
-    task.set("maxRewardWei", await computeMaxRewardWei(maxRewardETH));
-    const res = await task.save();
-    return res.id;
-  }
-
-  async function insertNewQuestions(newTask, taskId) {
-    const tableName = "Questions";
-
-    const Questions = Moralis.Object.extend(tableName);
-
-    newTask["questions"].forEach(async (question, idx) => {
-      const q = new Questions();
-      q.set("taskId", taskId);
-      q.set("type", question["type"]);
-      q.set("title", question["question"]);
-      q.set("idx", idx);
-      q.set("options", question["options"]);
-      await q.save();
-    });
-  }
-
-  const ethAddress = request.user.get("ethAddress");
-  const newTask = request.params.newTask;
-  const maxRewardETH = request.params.maxRewardETH;
-  const maxResponses = Number(request.params.maxResponses);
-  const config = await Moralis.Config.get({ useMasterKey: true });
-
-  if (!validateNewTask(newTask, maxRewardETH, maxResponses, config))
-    return {
-      success: false,
-      message: `Address ${ethAddress} failed to create task "${newTask["title"]}": please provide valid inputs`,
+Moralis.Cloud.define(
+  "createTask",
+  async (request) => {
+    const QuestionType = {
+      SINGLE_CHOICE: 0,
     };
 
-  const taskId = await insertNewTask(newTask, maxRewardETH, maxResponses);
-  await insertNewQuestions(newTask, taskId);
+    function validateNewTask(newTask, maxRewardETH, maxResponses, config) {
+      const MIN_TASKERS = Number(config.get("NEXT_PUBLIC_MIN_TASKERS"));
+      const MIN_TASK_DATA_CHARS = Number(
+        config.get("NEXT_PUBLIC_MIN_TASK_DATA_CHARS")
+      );
+      const MIN_ETH = Number(config.get("NEXT_PUBLIC_MIN_ETH"));
 
-  return {
-    success: true,
-    message: `Address ${ethAddress} succesfully created task "${newTask["title"]}"!`,
-  };
-});
+      if (maxRewardETH < MIN_ETH) return false;
+      if (maxResponses < MIN_TASKERS) return false;
+      if (!Number.isInteger(maxResponses)) return false;
+      if (newTask["title"].length < MIN_TASK_DATA_CHARS) return false;
+      if (newTask["description"].length < MIN_TASK_DATA_CHARS) return false;
+      if (
+        newTask["questions"].some(
+          (question) => question["question"].length < MIN_TASK_DATA_CHARS
+        )
+      )
+        return false;
+      if (
+        newTask["questions"].some((question) => {
+          // See enum QuestionType for type IDs
+
+          // Multiple choice
+          if (question["type"] === QuestionType.SINGLE_CHOICE) {
+            // Check that number of choices is in [1, 5]
+            if (
+              question["options"].length < 1 ||
+              question["options"].length > 5
+            )
+              return true;
+            return false;
+          }
+
+          // Invalid/unknown question type, so fail
+          return true;
+        })
+      )
+        return false;
+
+      // All checks passed at this point
+      return true;
+    }
+
+    async function insertNewTask(newTask, maxRewardETH, maxResponses) {
+      const tableName = "Tasks";
+
+      const Tasks = Moralis.Object.extend(tableName);
+
+      const task = new Tasks();
+      task.set("requesterId", ethAddress);
+      task.set("title", newTask["title"]);
+      task.set("description", newTask["description"]);
+      task.set("startDate", new Date());
+      task.set("status", 0); // "in progress"
+      task.set(
+        "estCompletionTime",
+        Math.ceil((newTask["questions"].length * 30) / 60)
+      ); // approx 30 seconds per question @bzzbbz @christine-sun @jennsun @nicholaspad
+      task.set("avgRating", -1);
+      task.set("numResponses", 0);
+      task.set("maxResponses", maxResponses);
+      task.set(
+        "unitRewardWei",
+        await computeUnitRewardWei(maxRewardETH, maxResponses)
+      );
+      task.set("maxRewardWei", await computeMaxRewardWei(maxRewardETH));
+      const res = await task.save();
+      return res.id;
+    }
+
+    async function insertNewQuestions(newTask, taskId) {
+      const tableName = "Questions";
+
+      const Questions = Moralis.Object.extend(tableName);
+
+      newTask["questions"].forEach(async (question, idx) => {
+        const q = new Questions();
+        q.set("taskId", taskId);
+        q.set("type", question["type"]);
+        q.set("title", question["question"]);
+        q.set("idx", idx);
+        q.set("options", question["options"]);
+        await q.save();
+      });
+    }
+
+    const ethAddress = request.user.get("ethAddress");
+    const newTask = request.params.newTask;
+    const maxRewardETH = request.params.maxRewardETH;
+    const maxResponses = Number(request.params.maxResponses);
+    const config = await Moralis.Config.get({ useMasterKey: true });
+
+    if (!validateNewTask(newTask, maxRewardETH, maxResponses, config))
+      return {
+        success: false,
+        message: `Address ${ethAddress} failed to create task "${newTask["title"]}": please provide valid inputs`,
+      };
+
+    const taskId = await insertNewTask(newTask, maxRewardETH, maxResponses);
+    await insertNewQuestions(newTask, taskId);
+
+    return {
+      success: true,
+      message: `Address ${ethAddress} succesfully created task "${newTask["title"]}"!`,
+    };
+  },
+  {
+    fields: ["newTask", "maxRewardETH", "maxResponses"],
+    requireUser: true,
+  }
+);

--- a/components/tables/TasksTable.tsx
+++ b/components/tables/TasksTable.tsx
@@ -43,11 +43,11 @@ export default function TasksTable(props: {
       sortable: false,
       disableColumnMenu: true,
       type: "number",
-      minWidth: 150,
+      minWidth: 200,
       align: "left",
-      renderHeader: () => <TableHeader>Reward</TableHeader>,
+      renderHeader: () => <TableHeader>ETH Reward</TableHeader>,
       renderCell: (params: GridValueGetterParams) => (
-        <TableCell>{params.row.reward} ETH</TableCell>
+        <TableCell>{params.row.reward}</TableCell>
       ),
     },
   ];

--- a/components/task/TaskOverview.tsx
+++ b/components/task/TaskOverview.tsx
@@ -87,7 +87,7 @@ export default function TaskOverviewTemplate(props: {
                 <SectionTitle>Reward</SectionTitle>
                 <Box
                   borderRadius={2}
-                  width={230}
+                  width="fit-content"
                   display="flex"
                   flexDirection="row"
                   alignItems="center"
@@ -96,6 +96,7 @@ export default function TaskOverviewTemplate(props: {
                   mb={3}
                   mx="auto"
                   py={1}
+                  px={2}
                   sx={{
                     backgroundImage: `linear-gradient(90deg, ${gigTheme.palette.primaryCTA.primary}, ${gigTheme.palette.primaryCTA.secondary})`,
                   }}

--- a/pages/requester/my-tasks.tsx
+++ b/pages/requester/my-tasks.tsx
@@ -79,21 +79,6 @@ export default function MyTasks() {
       ),
     },
     {
-      field: "maxRewardWei",
-      sortable: false,
-      disableColumnMenu: true,
-      type: "number",
-      minWidth: 180,
-      align: "left",
-      renderHeader: () => <TableHeader>ETH Used / Max</TableHeader>,
-      renderCell: (params: GridValueGetterParams) => (
-        <TableCell>
-          {params.row.numResponses * params.row.reward} /{" "}
-          {params.row.maxRewardWei}
-        </TableCell>
-      ),
-    },
-    {
       field: "numResponses",
       sortable: false,
       disableColumnMenu: true,
@@ -104,6 +89,21 @@ export default function MyTasks() {
       renderCell: (params: GridValueGetterParams) => (
         <TableCell>
           {params.row.numResponses} / {params.row.maxResponses}
+        </TableCell>
+      ),
+    },
+    {
+      field: "maxRewardWei",
+      sortable: false,
+      disableColumnMenu: true,
+      type: "number",
+      minWidth: 450,
+      align: "left",
+      renderHeader: () => <TableHeader>ETH Used / Max</TableHeader>,
+      renderCell: (params: GridValueGetterParams) => (
+        <TableCell>
+          {params.row.numResponses * params.row.reward} /{" "}
+          {params.row.maxRewardWei}
         </TableCell>
       ),
     },

--- a/pages/requester/my-tasks.tsx
+++ b/pages/requester/my-tasks.tsx
@@ -15,6 +15,100 @@ export default function MyTasks() {
   const { isInitialized, Moralis } = useMoralis();
   const [data, setData] = useState<TaskData[]>();
 
+  const extraColumns: GridColDef[] = [
+    {
+      field: "status",
+      sortable: false,
+      disableColumnMenu: true,
+      type: "string",
+      minWidth: 120,
+      align: "left",
+      renderHeader: () => <TableHeader>Status</TableHeader>,
+      renderCell: (params: GridValueGetterParams) => (
+        <TableCell
+          color={createdStatusColorMap[params.row.status as CreatedTaskStatus]}
+        >
+          {createdStatusMap[params.row.status as CreatedTaskStatus]}
+        </TableCell>
+      ),
+    },
+    {
+      field: "",
+      headerName: "",
+      sortable: false,
+      disableColumnMenu: true,
+      minWidth: data?.some((e) => e.status === 0) ? 290 : 165,
+      flex: 1,
+      align: "left",
+      renderCell: (params: GridValueGetterParams) => (
+        <>
+          {/* Render Abandon buttons for "In Progress" rows */}
+          {/* Use compact rendering if there are no "In Progress" rows */}
+          {data?.some((e) => e.status === 0) ? (
+            <Box
+              visibility={
+                (params.row.status as CreatedTaskStatus) >= 1
+                  ? "hidden"
+                  : "visible"
+              }
+              mr={2}
+            >
+              <SecondaryButtonCTA
+                text="Abandon"
+                size="small"
+                to="/requester/my-tasks"
+              />
+            </Box>
+          ) : null}
+          <PrimaryButtonCTA
+            text={
+              (params.row.status as CreatedTaskStatus) === 0
+                ? "Approvals"
+                : "Overview"
+            }
+            size="small"
+            to={
+              (params.row.status as CreatedTaskStatus) === 0
+                ? "/requester/my-tasks" // TODO @nicholaspad @bzzbbz replace with link to page to approve pending tasks
+                : `/tasker/task-overview/${String(
+                    params.row.task_id
+                  )}?back=/requester/my-tasks`
+            }
+          />
+        </>
+      ),
+    },
+    {
+      field: "maxRewardWei",
+      sortable: false,
+      disableColumnMenu: true,
+      type: "number",
+      minWidth: 180,
+      align: "left",
+      renderHeader: () => <TableHeader>ETH Used / Max</TableHeader>,
+      renderCell: (params: GridValueGetterParams) => (
+        <TableCell>
+          {params.row.numResponses * params.row.reward} /{" "}
+          {params.row.maxRewardWei}
+        </TableCell>
+      ),
+    },
+    {
+      field: "numResponses",
+      sortable: false,
+      disableColumnMenu: true,
+      type: "number",
+      minWidth: 220,
+      align: "left",
+      renderHeader: () => <TableHeader># Completed / Max</TableHeader>,
+      renderCell: (params: GridValueGetterParams) => (
+        <TableCell>
+          {params.row.numResponses} / {params.row.maxResponses}
+        </TableCell>
+      ),
+    },
+  ];
+
   useEffect(() => {
     if (!isInitialized) return;
 
@@ -50,93 +144,6 @@ export default function MyTasks() {
     </>
   );
 }
-
-const extraColumns: GridColDef[] = [
-  {
-    field: "status",
-    sortable: false,
-    disableColumnMenu: true,
-    type: "string",
-    minWidth: 120,
-    align: "left",
-    renderHeader: () => <TableHeader>Status</TableHeader>,
-    renderCell: (params: GridValueGetterParams) => (
-      <TableCell
-        color={createdStatusColorMap[params.row.status as CreatedTaskStatus]}
-      >
-        {createdStatusMap[params.row.status as CreatedTaskStatus]}
-      </TableCell>
-    ),
-  },
-  {
-    field: "",
-    headerName: "",
-    sortable: false,
-    disableColumnMenu: true,
-    minWidth: 165,
-    flex: 1,
-    align: "left",
-    renderCell: (params: GridValueGetterParams) => (
-      <>
-        {/* Render Abandon buttons for "In Progress" rows */}
-        {/* <Box
-          visibility={
-            (params.row.status as TaskStatus) >= 1 ? "hidden" : "visible"
-          }
-          mr={2}
-        >
-          <SecondaryButtonCTA
-            text="Abandon"
-            size="small"
-            to="/requester/my-tasks"
-          />
-        </Box> */}
-        <PrimaryButtonCTA
-          text={
-            (params.row.status as TaskStatus) === 0 ? "Approvals" : "Overview"
-          }
-          size="small"
-          to={
-            (params.row.status as TaskStatus) === 0
-              ? "/requester/my-tasks" // TODO @nicholaspad @bzzbbz replace with link to page to approve pending tasks
-              : `/tasker/task-overview/${String(
-                  params.row.task_id
-                )}?back=/requester/my-tasks`
-          }
-        />
-      </>
-    ),
-  },
-  {
-    field: "maxRewardWei",
-    sortable: false,
-    disableColumnMenu: true,
-    type: "number",
-    minWidth: 180,
-    align: "left",
-    renderHeader: () => <TableHeader>ETH Used / Max</TableHeader>,
-    renderCell: (params: GridValueGetterParams) => (
-      <TableCell>
-        {params.row.numResponses * params.row.reward} /{" "}
-        {params.row.maxRewardWei}
-      </TableCell>
-    ),
-  },
-  {
-    field: "numResponses",
-    sortable: false,
-    disableColumnMenu: true,
-    type: "number",
-    minWidth: 220,
-    align: "left",
-    renderHeader: () => <TableHeader># Completed / Max</TableHeader>,
-    renderCell: (params: GridValueGetterParams) => (
-      <TableCell>
-        {params.row.numResponses} / {params.row.maxResponses}
-      </TableCell>
-    ),
-  },
-];
 
 const createdStatusMap = {
   0: "In Progress",

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -82,6 +82,16 @@ export async function taskerAbandonTask(
   return await Moralis.Cloud.run("taskerAbandonTask", { taskId: taskId });
 }
 
+/*
+  Abandons a task (Requester functionality).
+*/
+export async function requesterAbandonTask(
+  Moralis: MoralisType,
+  taskId: string
+): Promise<{ success: boolean; message: string }> {
+  return await Moralis.Cloud.run("requesterAbandonTask", { taskId: taskId });
+}
+
 /* 
   Post a new task (Requester functionality).
 */


### PR DESCRIPTION
## Summary

- Add ability for Requesters to abandon an "in progress" task
    - Refund should be issued for whatever stake is remaining (i.e. unpaid to Taskers)
    - All linked data in the `TaskUsers`, `Tasks`, and `Questions` collection is deleted, with the exception of `TaskUsers` entries where the status is "Verified & Paid"
- Add schema and authentication validation to all Moralis Cloud functions
- Give more horizontal space to columns with crypto values